### PR TITLE
Don't force unicode when validating package name

### DIFF
--- a/XS.xs
+++ b/XS.xs
@@ -192,7 +192,6 @@ static int _is_valid_module_name(SV *package)
     sv_upgrade(sv, SVt_PV);
     SvREADONLY_on(sv);
     SvLEN(sv) = 0;
-    SvUTF8_on(sv);
     SvPVX(sv) = buf;
     SvCUR_set(sv, len);
     SvPOK_on(sv);
@@ -956,6 +955,7 @@ BOOT:
         PMOP fakepmop;
 
         fakepmop.op_pmflags = 0;
+        fakepmop.op_pmdynflags = 0;
         valid_module_regex = pregcomp(vmre, vmre + strlen(vmre), &fakepmop);
 #else
         SV *re;

--- a/t/debug.t
+++ b/t/debug.t
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+use Test::More;
+BEGIN {
+  # shut up the debugger
+  $ENV{PERLDB_OPTS} = 'NonStop';
+}
+
+BEGIN {
+
+#line 1
+#!/usr/bin/perl -d
+#line 14
+
+}
+
+use Package::Stash::XS;
+
+use Devel::Peek;
+
+eval {
+    Package::Stash::XS->new('Package::Stash::XS');
+};
+
+is $@, '',
+    'no errors getting stash under debugger';
+
+__END__
+my $utf8_package = eval q{"Package::WithUnicode\x{7EF4}::Characters"};
+
+eval {
+    Package::Stash::XS->new($utf8_package);
+};
+
+like $@, qr/is not a module name/,
+    'Unicode characters in stash names rejected';
+
+done_testing;


### PR DESCRIPTION
Incoming package stash names usually don't contain unicode, and we already
reject them if they do.  Since we reject them, doing unicode matching
serves no purpose.  Don't UTF8 enable the extra sv given to pregexec,
and initialize the op_pmdynflags flags to 0 on perl 5.8.

This should serve as a slight optimization to execution time, and will
prevent utf8.pm from being automatically loaded.  On perl 5.8.6 and
below, loading utf8.pm during the regex execution doesn't work
correctly, and will cause the regex to fail against some valid inputs.
